### PR TITLE
Fix #68441: wrong ZPP for svn_diff()

### DIFF
--- a/svn.c
+++ b/svn.c
@@ -1340,7 +1340,7 @@ PHP_FUNCTION(svn_diff)
 	svn_opt_revision_t revision1, revision2;
 	zend_bool ignore_content_type = 0;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl!sl!",
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slsl",
 			&path1, &path1len, &rev1,
 			&path2, &path2len, &rev2)) {
 		return;


### PR DESCRIPTION
If a `zend_long` parameter is nullable, it needs an additional
`zend_bool` argument which indicates whether the passed argument
actually was `NULL`; otherwise the parameter memory will be corrupted.

Since the default value of these parameters is `SVN_REVISION_HEAD`
anyway, there is no need for the parameters to be nullable at all.
This also matches the "proto" and the docs.  This is also not a real
BC break, since passing `NULL` to these parameters likely crashes
anyway.

The patch has been provided by the bug reporter.