### PR TITLE
A minimal CI for building and testing the extension on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+on: [push, pull_request]
+jobs:
+  ubuntu:
+    strategy:
+      matrix:
+          version: ['7.3', '7.4']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install libsvn-dev
+      - name: Checkout svn
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{matrix.version}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: ./configure --with-svn
+      - name: make
+        run: make
+      - name: Test svn
+        run: make test TESTS='--show-diff tests'

--- a/tests/status.phpt
+++ b/tests/status.phpt
@@ -24,14 +24,14 @@ include('utils.inc');
 delete_directory(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'wc');
 
 ?>
---EXPECT--
+--EXPECTF--
 array(0) {
 }
 array(2) {
   [0]=>
   array(16) {
     ["path"]=>
-    string(31) "/home/develar/pecl_svn/tests/wc"
+    string(%d) "%s/tests/wc"
     ["text_status"]=>
     int(3)
     ["repos_text_status"]=>
@@ -49,9 +49,9 @@ array(2) {
     ["name"]=>
     string(0) ""
     ["url"]=>
-    string(37) "file:///home/develar/pecl_svn/tests/r"
+    string(%d) "file://%s/tests/r"
     ["repos"]=>
-    string(37) "file:///home/develar/pecl_svn/tests/r"
+    string(%d) "file://%s/tests/r"
     ["revision"]=>
     int(2)
     ["kind"]=>
@@ -66,7 +66,7 @@ array(2) {
   [1]=>
   &array(16) {
     ["path"]=>
-    string(36) "/home/develar/pecl_svn/tests/wc/test"
+    string(%d) "%s/tests/wc/test"
     ["text_status"]=>
     int(3)
     ["repos_text_status"]=>
@@ -84,9 +84,9 @@ array(2) {
     ["name"]=>
     string(4) "test"
     ["url"]=>
-    string(42) "file:///home/develar/pecl_svn/tests/r/test"
+    string(%d) "file://%s/tests/r/test"
     ["repos"]=>
-    string(37) "file:///home/develar/pecl_svn/tests/r"
+    string(%d) "file://%s/tests/r"
     ["revision"]=>
     int(2)
     ["kind"]=>


### PR DESCRIPTION
There are no official libsvn packages available for Windows, so we
stick with Linux for now.  We also stick with PHP 7.3 and 7.4, since
PHP 8.0 is not yet supported[1].

We also make status.phpt more generic, by no longer checking for system
specific paths.

[1] <https://bugs.php.net/80467>
